### PR TITLE
feat: Throw PoHTTPInvalidParcelError when server refuses parcel

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,2 +1,3 @@
 export * from './lib/client';
 export { default as PoHTTPError } from './lib/PoHTTPError';
+export { default as PoHTTPInvalidParcelError } from './lib/PoHTTPInvalidParcelError';

--- a/src/integration_tests/main.test.ts
+++ b/src/integration_tests/main.test.ts
@@ -1,8 +1,14 @@
-import { deliverParcel } from '..';
+import { deliverParcel, PoHTTPInvalidParcelError } from '..';
 
 test('307 redirect', async () => {
   const response = await deliverParcel('https://httpstat.us/307', Buffer.from('hey'));
 
   expect(response).toHaveProperty('config.url', 'https://httpstat.us');
   expect(response.request).toHaveProperty('shouldKeepAlive', true);
+});
+
+test('403 status code', async () => {
+  await expect(deliverParcel('https://httpstat.us/403', Buffer.from('hey'))).rejects.toBeInstanceOf(
+    PoHTTPInvalidParcelError,
+  );
 });

--- a/src/lib/PoHTTPInvalidParcelError.ts
+++ b/src/lib/PoHTTPInvalidParcelError.ts
@@ -1,0 +1,3 @@
+import PoHTTPError from './PoHTTPError';
+
+export default class PoHTTPInvalidParcelError extends PoHTTPError {}

--- a/src/lib/client.spec.ts
+++ b/src/lib/client.spec.ts
@@ -4,6 +4,7 @@ import bufferToArray from 'buffer-to-arraybuffer';
 import { expectPromiseToReject, getMockContext, mockEnvVars } from './_test_utils';
 import { deliverParcel, DeliveryOptions } from './client';
 import PoHTTPError from './PoHTTPError';
+import PoHTTPInvalidParcelError from './PoHTTPInvalidParcelError';
 
 describe('deliverParcel', () => {
   const url = 'https://example.com';
@@ -226,6 +227,16 @@ describe('deliverParcel', () => {
 
       expect(response).toBe(stubResponse);
     });
+  });
+
+  test('HTTP 403 should throw a PoHTTPInvalidParcelError', async () => {
+    // @ts-ignore
+    stubAxiosPost.mockReset();
+    stubAxiosPost.mockRejectedValueOnce({ response: { status: 403 } });
+
+    await expect(deliverParcel(url, body)).rejects.toEqual(
+      new PoHTTPInvalidParcelError('Server refused to accept parcel'),
+    );
   });
 
   test('Unexpected axios exceptions should be wrapped rethrown', async () => {

--- a/src/lib/client.ts
+++ b/src/lib/client.ts
@@ -3,6 +3,7 @@ import { get as getEnvVar } from 'env-var';
 import * as https from 'https';
 
 import PoHTTPError from './PoHTTPError';
+import PoHTTPInvalidParcelError from './PoHTTPInvalidParcelError';
 
 export interface DeliveryOptions {
   readonly gatewayAddress: string;
@@ -65,6 +66,9 @@ async function postRequest(
     });
   } catch (error) {
     const responseStatus = error.response?.status;
+    if (responseStatus && responseStatus === 403) {
+      throw new PoHTTPInvalidParcelError('Server refused to accept parcel');
+    }
     if (!responseStatus || responseStatus < 300 || 400 <= responseStatus) {
       throw new PoHTTPError(error, 'Failed to deliver parcel');
     }


### PR DESCRIPTION
As now required in PoHTTP: https://github.com/relaynet/specs/commit/3ac15dd280b9bfc1e4e58631ae12fc28452d0275

Done as part of https://github.com/relaycorp/relaynet-internet-gateway/pull/33
