### PR TITLE
fix: Remove Axios config from errors

### DIFF
--- a/src/lib/client.spec.ts
+++ b/src/lib/client.spec.ts
@@ -16,7 +16,10 @@ describe('deliverParcel', () => {
     stubAxiosPost.mockResolvedValueOnce(stubResponse);
 
     // @ts-ignore
-    jest.spyOn(axios, 'create').mockReturnValueOnce({ post: stubAxiosPost });
+    jest.spyOn(axios, 'create').mockReturnValueOnce({
+      interceptors: { response: { use: jest.fn() } } as any,
+      post: stubAxiosPost,
+    });
   });
 
   afterEach(() => {
@@ -80,6 +83,14 @@ describe('deliverParcel', () => {
     expect(axiosCreateCall[0]).toHaveProperty('httpsAgent');
     const agent = axiosCreateCall[0].httpsAgent;
     expect(agent).toHaveProperty('keepAlive', true);
+  });
+
+  test('An interceptor that removes the request and response should be registered', async () => {
+    ((axios.create as any) as jest.MockInstance<any, any>).mockRestore();
+
+    await expect(deliverParcel('https://httpstat.us/500', body)).rejects.not.toHaveProperty(
+      'jse_cause.config',
+    );
   });
 
   describe('POHTTP_TLS_REQUIRED', () => {

--- a/src/lib/client.ts
+++ b/src/lib/client.ts
@@ -33,6 +33,13 @@ export async function deliverParcel(
     headers: { 'Content-Type': 'application/vnd.relaynet.parcel' },
     httpsAgent: new https.Agent({ keepAlive: true }),
   });
+
+  // Remove the request and response from the error cause to avoid filling the logs with
+  // unnecessary information. See: https://github.com/axios/axios/issues/2602
+  axiosInstance.interceptors.response.use(undefined, async error =>
+    Promise.reject(new Error(error.message)),
+  );
+
   const response = await postRequest(targetNodeUrl, parcelSerialized, axiosInstance, axiosOptions);
   if (response.status === 307 || response.status === 308) {
     throw new PoHTTPError(`Reached maximum number of redirects (${axiosOptions.maxRedirects})`);


### PR DESCRIPTION
To avoid filling the logs with unnecessary information